### PR TITLE
MNT: add cell timeout of 300s, allow errors in cells

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,8 @@ copyright: '2022'
 # Execute the notebooks upon build
 execute:
   execute_notebooks: auto
+  timeout: 300
+  allow_errors: true
 
 # Add a few extensions to help with parsing content
 parse:


### PR DESCRIPTION
- The baltrad notebooks exceed the default cell timeout of 50 seconds. Setting this to 300 for now. 
- There is one cell creating an error which stops notebook execution. Allowing errors for now to actually see this in the notebooks.