### PR TITLE
MNT: use repo2docker

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -25,48 +25,37 @@ on:
         type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483
 
 jobs:
-  build:
+  build-container:
     runs-on: ubuntu-latest
+    steps:
+      - name: checkout files in repo
+        uses: actions/checkout@main
+      - name: remove Dockerfile
+        run: |
+          rm binder/Dockerfile
+      - name: update jupyter dependencies with repo2docker
+        uses: jupyterhub/repo2docker-action@master
+        with:
+          DOCKER_USERNAME: ${{ github.actor }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_REGISTRY: "ghcr.io"
+          PUBLIC_REGISTRY_CHECK: true
+
+  build-book:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/openradar/erad2022:latest
+      options: --user root
+    needs: [build-container]
     defaults:
       run:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-
-      - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          activate-environment: ${{ inputs.environment_name }}
-          use-mamba: true
-
-      - name: Set cache date
-        if: ${{ inputs.use_cached_environment == 'true' }}
-        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-
-      - uses: actions/cache@v3
-        if: inputs.use_cached_environment == 'true'
-        with:
-          path: /usr/share/miniconda3/envs/${{ inputs.environment_name }}
-          key: linux-64-conda-${{ hashFiles('${{ inputs.environment_file }}') }}-${{ env.DATE }}
-        id: cache
-
-      - name: Update environment
-        if: |
-          inputs.use_cached_environment != 'true'
-          || steps.cache.outputs.cache-hit != 'true'
-        run: mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
-
-      - name: Install baltrad
-        run: |
-          set -x
-          set +e
-          export BALTRAD_INSTALL_ROOT=$PWD
-          bash -l $BALTRAD_INSTALL_ROOT/install/baltrad/install_baltrad.sh
-
       - name: Build the book
         run: |
+          # copy baltrad notebooks to book dir
+          cp -rp /home/jovyan/notebooks/baltrad* notebooks/.
           install/nbstripout_notebooks.sh
           jupyter-book build ${{ inputs.path_to_notebooks }}
       - name: Zip the book

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/openradar/erad2022:latest

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - xarray
   - wradlib
   - arm_pyart
-  - nbstripout
   # this is needed for baltrad compilation
   - compilers
   - make
@@ -25,3 +24,9 @@ dependencies:
   - tar
   - libblas=*=*netlib
   - liblapacke=*=*netlib
+  # this is needed for notebooks
+  - pyviz_comms>=2.0
+  - nbstripout
+  - zip
+  - pip:
+      - sphinx-pythia-theme

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-# installing extensions
-# kmuehlbauer: this seems to not work currently
-jupyter labextension install @pyviz/jupyterlab_pyviz \
-                             jupyter-leaflet
-
-
 # INSTALLING BALTRAD
 CONDA_DIR=/srv/conda
 RADARENV=notebook


### PR DESCRIPTION
1. use repo2docker to build and push image to ghcr.io
1. use image to build book
1. several fixes

The docker image is build in a preceding job and pushed to https://ghcr.io/openradar. This image is used in a second job to build the book. Additionally the same image is used as base image with binder, so that the image is built only once. 

closes #28 