### PR TITLE
ADD: update wradlib version to 1.16.2

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - cartopy
   - pandas
   - xarray
-  - wradlib=1.16.1
+  - wradlib=1.16.2
   - dask
   - tqdm
   - hvplot

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.9
   - jupyter-book
   - pip
-  - wradlib=1.16.1
+  - wradlib=1.16.2
   - dask
   - tqdm
   - hvplot


### PR DESCRIPTION
This will fix the currently broken `baltrad2wradlib` notebook.