### PR TITLE
MNT: checkout v3

### DIFF
--- a/.github/workflows/build-book-pullrequest.yaml
+++ b/.github/workflows/build-book-pullrequest.yaml
@@ -32,7 +32,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: checkout files in repo
-        uses: actions/checkout@main
+        uses: actions/checkout@v3
       - name: remove Dockerfile
         run: |
           rm binder/Dockerfile
@@ -45,6 +45,7 @@ jobs:
           DOCKER_REGISTRY: "ghcr.io"
           PUBLIC_REGISTRY_CHECK: true
           APPENDIX_FILE: "binder/appendix.txt"
+          REPO2DOCKER_EXTRA_ARGS: --Repo2Docker.base_image=docker.io/library/buildpack-deps:bionic
       - name: list docker images
         run: |
           docker image ls -a

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout files in repo
-        uses: actions/checkout@main
+        uses: actions/checkout@v3
       - name: remove Dockerfile
         run: |
           rm binder/Dockerfile
@@ -53,7 +53,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build the book
         run: |
           # copy baltrad notebooks to book dir


### PR DESCRIPTION
see https://github.com/actions/checkout/issues/1590 and https://github.com/openradar/erad2022/actions/runs/7970881407/job/21760007234

> Run actions/checkout@v4
> /usr/bin/docker exec  ecf8b7c89a935d27067213571f6817cfde75c0635fc33811b9a7d4db0d06301e sh -c "cat /etc/*release | grep ^ID"
> /__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)