### PR TITLE
Revert "Bump actions/checkout from 3 to 4"

### DIFF
--- a/.github/workflows/build-book-pullrequest.yaml
+++ b/.github/workflows/build-book-pullrequest.yaml
@@ -32,7 +32,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: checkout files in repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: remove Dockerfile
         run: |
           rm binder/Dockerfile

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout files in repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: remove Dockerfile
         run: |
           rm binder/Dockerfile
@@ -54,7 +54,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build the book
         run: |
           # copy baltrad notebooks to book dir


### PR DESCRIPTION
Reverts openradar/erad2022#105

This actually doesn't work because of https://github.com/actions/checkout/issues/1590